### PR TITLE
try to simplify Django 1.8/Django 1.11 compatibility

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -47,7 +47,7 @@ def main():
             test_cmd = ['coverage', 'run']
         else:
             test_cmd = []
-        test_cmd += [django_admin, 'test']
+        test_cmd += [django_admin, 'test', '--keepdb']
         results.append(call(test_cmd))
         if args.with_coverage:
             results.append(call(['coverage', 'report', '-m', '--fail-under', '70']))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -165,15 +165,15 @@ class CachingTestCase(TestCase):
         raw2 = list(Addon.objects.raw(sql, [2]))[0]
         self.assertEqual(raw2.id, 2)
 
-    @mock.patch('caching.base.CacheMachine')
-    def test_raw_nocache(self, CacheMachine):
+    @mock.patch('caching.base.CachingModelIterable')
+    def test_raw_nocache(self, CachingModelIterable):
         base.TIMEOUT = 60
         sql = 'SELECT * FROM %s WHERE id = 1' % Addon._meta.db_table
         raw = list(Addon.objects.raw(sql, timeout=config.NO_CACHE))
         self.assertEqual(len(raw), 1)
         raw_addon = raw[0]
         self.assertFalse(hasattr(raw_addon, 'from_cache'))
-        self.assertFalse(CacheMachine.called)
+        self.assertFalse(CachingModelIterable.called)
 
     @mock.patch('caching.base.cache')
     def test_count_cache(self, cache_mock):


### PR DESCRIPTION
I did manage to get this working, and I think it's a little simpler because most of the Django 1.8 - 1.11 conditionals (other than for defining `ModelIterable`) could be removed.

I didn't realize before that `iter_function` was/is used for `RawQuerySet` too, not just Django 1.8 (that was the cause of a few test failures while figuring this out).

I feel like there's probably a way to get rid of `if self.iter_function is not None:` too, but haven't figured that out yet and need to shutdown for the moment.